### PR TITLE
feat: provide `paths` predicate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ buildcache
 *.key
 *.pem
 *.cert
+
+# Temp
+temp

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ Qorsproxy applies [the first matched](./src/main/js/servlet/corsproxy/rules.js#L
       "to": [
         "example.com"
       ],
+      "paths": [
+        "/"
+      ],
       "mutations": [
         {
           "direction": "to",

--- a/example/example.config.json
+++ b/example/example.config.json
@@ -11,6 +11,9 @@
       "to": [
         "example.com"
       ],
+      "paths": [
+        "/"
+      ],
       "interceptions": [
         {
           "req": {

--- a/src/main/js/config/schemas.js
+++ b/src/main/js/config/schemas.js
@@ -62,6 +62,7 @@ const RULE = {
     memo: MEMO,
     from: STRING_OR_STRING_ARRAY,
     to: STRING_OR_STRING_ARRAY,
+    paths: STRING_ARRAY,
     interceptions: { type: 'array', items: INTERCEPTION }
   }
 }

--- a/src/main/js/servlet/corsproxy/index.js
+++ b/src/main/js/servlet/corsproxy/index.js
@@ -55,7 +55,7 @@ export default class Server {
     const { from, to, secret, user, path, origin } = this.constructor.parse(req)
     const { host, port, securePort } = this
     const id = crypto.randomBytes(8).toString('hex')
-    const rule = this.rules.get(from, to, secret)
+    const rule = this.rules.get(from, to, secret, path)
 
     req.id = res.id = id
 

--- a/src/main/js/servlet/corsproxy/rules.js
+++ b/src/main/js/servlet/corsproxy/rules.js
@@ -32,9 +32,10 @@ export default class Rules {
    * @param {String} [origin]
    * @param {String} [host]
    * @param {String} [secret]
+   * @param {String} [path]
    * @returns {Object/null}
    */
-  get (origin, host, secret) {
+  get (origin, host, secret, path = '/') {
     // TODO Support ip
     // TODO Support masks
     // TODO Use TreeMap
@@ -54,6 +55,9 @@ export default class Rules {
       const rule = this.rules.get(key)
 
       if (rule) {
+        if (rule.paths?.every(p => !path.startsWith(p))) {
+            continue
+        }
         return rule
       }
     }

--- a/src/test/js/servlet/corsproxy/rules.test.js
+++ b/src/test/js/servlet/corsproxy/rules.test.js
@@ -28,16 +28,22 @@ describe('corsproxy.Rules', () => {
           from: 'foobar.com',
           to: ['baz.org', 'qux.org'],
           secret: 'f4091876df6a5d39e6690b7395a95399'
-        }
+        },
+        {
+          from: 'zone.local',
+          to: 'qiwi.com',
+          paths: ['/foo']
+        },
       ])
       expect([...rules.rules.keys()]).to.include(
         'localhost__*__*',
         '*__example.com__*',
         '*__*__4e99e8c12de7e01535248d2bac85e732',
         'foobar.com__baz.org__f4091876df6a5d39e6690b7395a95399',
-        'foobar.com__qux.org__f4091876df6a5d39e6690b7395a95399'
+        'foobar.com__qux.org__f4091876df6a5d39e6690b7395a95399',
+        'zone.local__qiwi.com__*'
       )
-      expect(rules.rules.size).to.equal(5)
+      expect(rules.rules.size).to.equal(6)
     })
 
     describe('`get`', () => {
@@ -49,6 +55,12 @@ describe('corsproxy.Rules', () => {
 
       it('extracts rule by strict match', () => {
         expect(rules.get('foobar.com', 'qux.org', 'f4091876df6a5d39e6690b7395a95399')).to.be.an('object')
+      })
+
+      it('extracts rule by path', () => {
+        expect(rules.get('zone.local', 'qiwi.com', null, '/foo/bar')).to.be.an('object')
+        expect(rules.get('zone.local', 'qiwi.com', null, '/foo/baz')).to.be.an('object')
+        expect(rules.get('zone.local', 'qiwi.com', null, '/bar')).to.be.null()
       })
 
       it('return null if no match found', () => {


### PR DESCRIPTION
```js
"rules": {
    "localhost": {
      "from": [      // localhost, 127.0.0.1, zone.local, etc
        "*"
      ],
      "to": [        // remote dest host
        "example.com"
      ],
      "paths": [     // ← applies the rule if the request matches to the one of given paths
        "/foo",
        "/bar"
      ],
      ...
```
